### PR TITLE
Fix vAccount action payload serialization to work with big payloads

### DIFF
--- a/boxes/groups/services/vaccounts-dapp-service/test/vaccountsconsumer.spec.js
+++ b/boxes/groups/services/vaccounts-dapp-service/test/vaccountsconsumer.spec.js
@@ -171,8 +171,25 @@ describe(`vAccounts Service Test Contract`, () => {
             res = (toBound(res.toString(16), 8));
             return res;
         }
-        var datasize = toBound(new BigNumber(response[0].data.length / 2).toString(16), 1).match(/.{2}/g).reverse().join('');
-        var payloadSerialized = header + "0000000000000000" + toName(payload.name) + "01" + "00000000000000000000000000000000" + datasize + response[0].data;
+
+        buffer.pushVaruint32(response[0].data.length / 2);
+        const varuintBytes = [];
+        while (buffer.haveReadData()) varuintBytes.push(buffer.get());
+        const serializedDataWithLength = Serialize.arrayToHex(Uint8Array.from(varuintBytes)) + response[0].data;
+
+        // payloadSerialized corresponds to the actual vAccount action (like regaccount) https://github.com/liquidapps-io/zeus-sdk/blob/a3041e9177ffe4375fd8b944f4a10f74a447e406/boxes/groups/services/vaccounts-dapp-service/contracts/eos/dappservices/_vaccounts_impl.hpp#L50-L60
+        // and is used as xvexec's payload vector<char>: https://github.com/liquidapps-io/zeus-sdk/blob/4e79122e42eeab50cf633097342b9c1fa00960c6/boxes/groups/services/vaccounts-dapp-service/services/vaccounts-dapp-service-node/index.js#L30
+        // eosio::action fields to serialize https://github.com/EOSIO/eosio.cdt/blob/master/libraries/eosiolib/action.hpp#L194-L221
+        const actionSerialized =
+        "0000000000000000" + // account_name
+        toName(payload.name) + // action_name
+        // std::vector<permission_level> authorization https://github.com/EOSIO/eosio.cdt/blob/master/libraries/eosiolib/action.hpp#L107-L155
+        "00" +
+        // std::vector<char> data;
+        serializedDataWithLength;
+
+        const payloadSerialized = header + actionSerialized;
+
         return await postVirtualTx({
             contract_code,
             wif,


### PR DESCRIPTION
The existing code to serialize vAccount actions only works with payloads that don't exceed a length of 255 bytes as it always uses a single byte for the payload size.
Although this works fine in your `vaccountconsumer` test due to the small payload, I think it's a good idea to change it there as well because I'm sure many developers, including me, will use that code as their starting point until there's documentation.

### Changelog

* Change the serialization of `data` to match the serialization in EOSIO's CPP datastream for `std::vector<char>` which uses a varuint32_t for the size.
* Serialize an empty `std::vector<permission_level> authorization` array instead of a one-element array with an empty permission level. This saves some bytes for every vAccount action.
* Add comments documenting what's going on.