### PR TITLE
added rc file functionality and rc file ignore flag

### DIFF
--- a/zeus-cmd/package.json
+++ b/zeus-cmd/package.json
@@ -23,6 +23,7 @@
     "babel-preset-latest": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
+    "camelcase": "^5.0.0",
     "chalk": "^2.4.1",
     "colorize": "^0.1.0",
     "colors": "^1.3.3",

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -41,7 +41,6 @@ var currentYargs = require('yargs') // eslint-disable-line
     } else if (argv['rc-ignore']) {
       console.log('ignoring rc file');
     }
-    console.log(argv);
     return argv;
   }, true)
   .option('verbose', {

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -25,21 +25,31 @@ var currentYargs = require('yargs') // eslint-disable-line
     describe: 'ignore rc file',
     default: false
   })
+  .middleware(argv => {
+    // Load rc file if any or report rc ignore to user
+    if (!argv['rc-ignore'] && fs.existsSync(argv['rc-file'])) {
+      console.log(`loading options from rc file ${argv['rc-file']}`);
+      const rc = JSON.parse(fs.readFileSync(argv['rc-file']));
+      var config = { ...rc.global };
+      var other = rc;
+      argv['_'].map(cmd => {
+        if (config[cmd]) delete config[cmd];
+        other = (other && cmd in other) ? other[cmd] : undefined;
+        if (other) config = { ...config, ...other };
+      });
+      argv = { ...argv, ...config };
+    } else if (argv['rc-ignore']) {
+      console.log('ignoring rc file');
+    }
+    console.log(argv);
+    return argv;
+  }, true)
   .option('verbose', {
     alias: 'v',
     default: false
   }).commandDir('cmds').help('help')
   .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
   .help('h').alias('h', 'help').demandCommand().completion().strict();
-
-// Load rc file if any or report rc ignore to user
-if (!currentYargs.argv.rcIgnore && fs.existsSync(currentYargs.argv.rcFile)) {
-  console.log(`loading options from rc file ${currentYargs.argv.rcFile}`);
-  const config = JSON.parse(fs.readFileSync(currentYargs.argv.rcFile));
-  currentYargs = currentYargs.config(config);
-} else if (currentYargs.argv.rcIgnore) {
-  console.log('ignoring rc file');
-}
 
 var extPath = path.join(path.resolve('.'), 'extensions/commands');
 if (fs.existsSync(extPath) && global.enableExt) { currentYargs = currentYargs.commandDir(extPath); }

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -4,6 +4,7 @@ require('babel-core/register');
 require('babel-polyfill');
 const path = require('path');
 const fs = require('fs');
+const camelcase = require('camelcase');
 
 global.enableExt = !(process.argv[2] == 'deploy' && process.argv[3] == 'box');
 global.enableExt = global.enableExt && !(process.argv[3] == 'deploy' && process.argv[4] == 'box');

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -30,14 +30,14 @@ var currentYargs = require('yargs') // eslint-disable-line
     if (!argv['rc-ignore'] && fs.existsSync(argv['rc-file'])) {
       console.log(`loading options from rc file ${argv['rc-file']}`);
       const rc = JSON.parse(fs.readFileSync(argv['rc-file']));
-      var config = { ...rc.global };
-      var other = rc;
-      argv['_'].map(cmd => {
-        if (config[cmd]) delete config[cmd];
-        other = (other && cmd in other) ? other[cmd] : undefined;
-        if (other) config = { ...config, ...other };
+      const validKeys = Object.keys(rc).filter(key => key in argv);
+      validKeys.map(key => {
+        argv[key] = rc[key];
+        const cam = camelcase(key);
+        if (cam in argv) {
+          argv[cam] = rc[key];
+        }
       });
-      argv = { ...argv, ...config };
     } else if (argv['rc-ignore']) {
       console.log('ignoring rc file');
     }

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -40,7 +40,6 @@ if (!currentYargs.argv.rcIgnore && fs.existsSync(currentYargs.argv.rcFile)) {
 } else if (currentYargs.argv.rcIgnore) {
   console.log('ignoring rc file');
 }
-console.log(currentYargs.argv)
 
 var extPath = path.join(path.resolve('.'), 'extensions/commands');
 if (fs.existsSync(extPath) && global.enableExt) { currentYargs = currentYargs.commandDir(extPath); }

--- a/zeus-cmd/src/index.js
+++ b/zeus-cmd/src/index.js
@@ -9,11 +9,21 @@ global.enableExt = !(process.argv[2] == 'deploy' && process.argv[3] == 'box');
 global.enableExt = global.enableExt && !(process.argv[3] == 'deploy' && process.argv[4] == 'box');
 
 const homedir = require('os').homedir();
+const storagePath = path.join(homedir, '.zeus');
+const rcFile = path.join(storagePath, 'zeusrc.json');
 var currentYargs = require('yargs') // eslint-disable-line
   .usage('Usage: $0 <cmd> [options]')
   .option('storage-path', {
     describe: 'path for persistent storage',
-    default: path.join(homedir, '.zeus')
+    default: storagePath
+  })
+  .option('rc-file', {
+    describe: 'use rc file to load options from',
+    default: rcFile
+  })
+  .option('rc-ignore', {
+    describe: 'ignore rc file',
+    default: false
   })
   .option('verbose', {
     alias: 'v',
@@ -21,6 +31,16 @@ var currentYargs = require('yargs') // eslint-disable-line
   }).commandDir('cmds').help('help')
   .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
   .help('h').alias('h', 'help').demandCommand().completion().strict();
+
+// Load rc file if any or report rc ignore to user
+if (!currentYargs.argv.rcIgnore && fs.existsSync(currentYargs.argv.rcFile)) {
+  console.log(`loading options from rc file ${currentYargs.argv.rcFile}`);
+  const config = JSON.parse(fs.readFileSync(currentYargs.argv.rcFile));
+  currentYargs = currentYargs.config(config);
+} else if (currentYargs.argv.rcIgnore) {
+  console.log('ignoring rc file');
+}
+console.log(currentYargs.argv)
 
 var extPath = path.join(path.resolve('.'), 'extensions/commands');
 if (fs.existsSync(extPath) && global.enableExt) { currentYargs = currentYargs.commandDir(extPath); }


### PR DESCRIPTION
This PR includes:
- RC file to load regular zeus-cmd options from, on `~/.zeus/zeusrc.json` by default, changeable with `--rc-file` option
- RC file ignore flag `--rc-ignore` to bypass it

handy to have custom defaults for `zeus` :)