### PR TITLE
Deploy box locally without the need for ipfs

### DIFF
--- a/zeus-cmd/src/cmds/deploy/box.js
+++ b/zeus-cmd/src/cmds/deploy/box.js
@@ -128,6 +128,8 @@ module.exports = {
       await Promise.race(urls.map(url => execPromise(`${process.env.CURL || 'curl'} --silent --output /dev/null ${url}`, {})));
     }
 
+    // console.log('cleaning up');
+    temp.cleanupSync();
     // var archive = `https://github.com/${}/${}/archive/master.zip`;
     // https://github.com/zeit/serve/archive/master.zip
     if (args['update-mapping']) {


### PR DESCRIPTION
In my case I have my own ipfs node in my machine for other purposes and didn't want to be forced to create another ipfs repo just to be able to use zeus.
So I found interesting to have another `--type local` that deploys boxes to a folder `~/.zeus/boxes/` in my storage directory and maps them in my mappings to a uri like `file:///...`, so that the unbox can find them and use as any other type.
Also found that invalidation of ipfs only makes sense when the type is ipfs.