### PR TITLE
fix error message when box doesn't exist in mappings

### DIFF
--- a/zeus-cmd/src/cmds/unbox.js
+++ b/zeus-cmd/src/cmds/unbox.js
@@ -162,7 +162,7 @@ const handler = async (args, globalCopyList = []) => {
       // code
     }
   } else {
-    throw new Error(`not supported yet. pass archive url ${args.box}`);
+    throw new Error(`box '${args.box}' not found. maybe mapping not updated?`);
   }
 
   // console.log(`extracting ${args.box}`);


### PR DESCRIPTION
When `zeus-cmd` couldn't find the box we wanted to unbox, the error message was like this:
```bash
$ zeus unbox invalid-box-name
⚙ Unboxing: invalid-box-name
Error: not supported yet. pass archive url invalid-box-name
```
That can be misleading, as the problem was that the box wasn't found and there was no valid uri for it... so I propose this change to the error message, so that the user might understand better what is going on:
```bash
$ zeus unbox invalid-box-name
⚙ Unboxing: invalid-box-name
Error: box 'invalid-box-name' not found. maybe mapping not updated?
```
Just a minor fix... :)