### PR TITLE
fixed problem with deploy box to ipfs on Mac OSX

### DIFF
--- a/zeus-cmd/src/cmds/deploy/box.js
+++ b/zeus-cmd/src/cmds/deploy/box.js
@@ -72,10 +72,7 @@ module.exports = {
       });
     }
 
-    var moddate = await execPromise(`find . -not -name "." -exec date -I -r '{}' \\; | sort -rn | head -1`, { cwd: stagingPath });
-    moddate = moddate.trim() + ' 00:00';
     stdout = await execPromise(`${process.env.ZIP || 'zip'} -X -r ./box.zip .`, { cwd: stagingPath });
-    // console.log("moddate",moddate)
 
     var uri = '';
     var hash;
@@ -102,7 +99,6 @@ module.exports = {
         var ipfsout = await execPromise(`${process.env.IPFS || 'ipfs'} add ./box.zip`, { cwd: stagingPath });
         hash = ipfsout.split(' ')[1];
         uri = `ipfs://${hash}`;
-        stdout = await execPromise(`touch -d "${moddate}" ./box.zip`, { cwd: stagingPath });
     }
 
     console.log(`box deployed to ${uri}`);


### PR DESCRIPTION
This problem kept me from exploring the full potential of `zeus-cmd` on the DAPP Network hackathon, as I use Mac OSX and it wasn't being able to deploy to IPFS, so I had to find a workaround for that issue... Now I found the problem, so here is the fix.
Before, with IPFS running and all set for deploy, the result on Mac was this:
```bash
$ zeus deploy box
staging in /var/folders/z4/qx7_sgbj2kx24xb20ljx_n_40000gn/T/zeus119113-98312-1l6xfjl.dwi2
{ Error: exec failed
    at ChildProcess.<anonymous> (/liqdapps/zeus-sdk/zeus-cmd/dist/helpers/_exec.js:73:19)
    at ChildProcess.emit (events.js:189:13)
    at ChildProcess.EventEmitter.emit (domain.js:441:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
  stdout: '',
  stderr:
   'touch: illegal option -- d\nusage:\ntouch [-A [-][[hh]mm]SS] [-acfhm] [-r file] [-t [[CC]YY]MMDDhhmm[.SS]] file ...\n',
  code: 1 }
```
There is a difference with the `touch` options between Linux and Mac OSX, so this error...
Linux man page: http://man7.org/linux/man-pages/man1/touch.1.html 
Mac man page: https://ss64.com/osx/touch.html
So it could be solved by changing the options, but after looking at the code I understood that that effort could be avoided as I found that the change of time on the file was completely irrelevant, and probably was just code that was left behind from previous logic, so I simply removed it and problem solved... :)