### PR TITLE
moved ipfs-daemon dependency from build-extensions into dapp-services

### DIFF
--- a/boxes/groups/core/build-extensions/zeus-box.json
+++ b/boxes/groups/core/build-extensions/zeus-box.json
@@ -5,7 +5,7 @@
   ],
   "commands": {
   },
-  "dependencies":["seed-extensions","ipfs-daemon"],
+  "dependencies":["seed-extensions"],
   "hooks": {
   }
 }

--- a/boxes/groups/dapp-network/dapp-services/zeus-box.json
+++ b/boxes/groups/dapp-network/dapp-services/zeus-box.json
@@ -4,7 +4,7 @@
     "LICENSE",
     "zeus-box.json"
   ],
-  "dependencies":["seed","seed-microservices","core-extensions","demux", "seed-eos", "events", "seed-models","hooks-cpp-contracts", "mocha", "client-lib-base"],
+  "dependencies":["seed","seed-microservices","core-extensions","demux", "seed-eos", "events", "seed-models","hooks-cpp-contracts", "mocha", "client-lib-base", "ipfs-daemon"],
   "install":{
     "contracts":{
       "dappservices": true


### PR DESCRIPTION
Moved ipfs-daemon dependency from build-extensions into dapp-services as it's not needed without dapp services.
Don't know if dapp-services box is the perfect one for that dependency, but now I am using zeus without any dapp service and having that ipfs dependency delays the unbox without any benefit...