### PR TITLE
Missing 'kill-port' npm dependency on eos-extensions box

### DIFF
--- a/boxes/groups/eos-sdk/eos-extensions/zeus-box.json
+++ b/boxes/groups/eos-sdk/eos-extensions/zeus-box.json
@@ -7,6 +7,11 @@
     "Start EOS Localenv": "zeus start-localenv"
   },
   "dependencies":["core-extensions" ],
+  "install": {
+    "npm":{
+      "kill-port": true
+    }
+  },
   "hooks": {
     "post-install": "bash extensions/scripts/install-eos.sh",
     "post-unpack": "bash extensions/scripts/install-eosio-cdt.sh"


### PR DESCRIPTION
Just a missing dependency needed while testing...