### PR TITLE
Fix dependencies that were missing from build

### DIFF
--- a/boxes/groups/dapp-network/client-lib-base/client/package.json
+++ b/boxes/groups/dapp-network/client-lib-base/client/package.json
@@ -23,8 +23,6 @@
   "author": "Natanael Prudhomme",
   "license": "BSD 3-Clause",
   "devDependencies": {
-    "bignumber.js": "^9.0.0",
-    "eosjs": "^20.0.0",
     "eosjs-ecc": "^4.0.7",
     "eslint": "^6.0.1"
   },
@@ -35,6 +33,8 @@
     "@types/isomorphic-fetch": "*",
     "@types/jest": "*",
     "@types/node": "^12.7.5",
+    "bignumber.js": "^9.0.0",
+    "eosjs": "^20.0.0",
     "babel-polyfill": "^6.26.0",
     "documentation": "*",
     "isomorphic-fetch": "*",


### PR DESCRIPTION
If you NPM install the @liquidapps/dapp-client library - and then `require` it in some node script, you'll get an error on missing dependencies for `eosjs` and `bignumber.js`.

That's because they're listed as `devDependencies` instead of `dependencies`.

So here, fixed it.