### PR TITLE
new feature: enabled 'GET' requests LiquidStorage's 'get_uri' to be a…

### DIFF
--- a/boxes/groups/services/storage-dapp-service/test/storage.spec.js
+++ b/boxes/groups/services/storage-dapp-service/test/storage.spec.js
@@ -420,4 +420,52 @@ describe(`LiquidStorage Test`, async () => {
       }
     })();
   });
+  
+  it('Upload html file and perform GET Request', done => {
+    (async () => {
+      try {
+        const data = Buffer.from("<html><head></head><body><h1>Hello, HTML!</h1></body></html>", "utf8");
+        const options = {
+          rawLeaves: true
+        };
+        const result = await storageClient.upload_public_file(
+          data,
+          key,
+          permission,
+          options
+        );
+        
+        // fetch data back from liquidstorage using a GET request and set response headers for 'Content-Type'
+        // and 'cross origin isolation' (check out: https://web.dev/coop-coep/ for more information!)
+        let url_params = '?uri=' + result.uri;
+        url_params += '&__content_type=text%2Fhtml%3B%20charset%3Dutf-8';
+        url_params += '&__cross_origin_opener_policy=same-origin';
+        url_params += '&__cross_origin_embedder_policy=require-corp';
+        res = await fetch(endpoint + '/v1/dsp/liquidstorag/get_uri' + url_params, {
+            method: 'GET',
+            mode: 'cors'
+        });
+
+        // check response headers
+        assert.equal(res.headers.get("content-type"), "text/html; charset=utf-8");
+        // cannot check the other response headers because of CORS mode!
+        // check https://stackoverflow.com/a/44816592/2340535 for more information
+
+        res = await res.arrayBuffer();
+        res = Buffer.from(new Uint8Array(res)).toString();
+        assert.equal(res, data);
+
+        console.log('Open the following link in a browser and check the console if "self.crossOriginIsolated" is set to "true":')
+        console.log(endpoint + '/v1/dsp/liquidstorag/get_uri' + url_params);
+        console.log('30 seconds timeout...');
+        await new Promise(resolve => setTimeout(resolve, 30000));
+
+        done();
+      } catch (e) {
+        console.log(e);
+        done(e);
+      }
+    })();
+  });
+  
 });


### PR DESCRIPTION
…ble to fetch browser content directly from LiquidStorage

A new LiquidApps' feature allowing for 'GET' requests of LiquidStorage's 'get_uri' RPC to enable web browsers to fetch content directly from IPFS and process it. DSPs become some kind of 'client-controlled' web servers that are now able to deliver IPFS content with certain HTTP headers set so that browsers know how to process the returned data and are able to execute applications in certain modes (like cross origin isolation). This feature makes LiquidStorage a true home for decentralized websites and Web3 applications as envisioned in this article: https://medium.com/the-liquidapps-blog/decentralized-storage-for-files-websites-and-more-liquidstorage-walkthrough-4a3c47d30ed6

I added the code for processing the GET request at the very beginning of the API handler as a special case. Why? Because it is a very special case that affects only the 'get_uri' RPC of the storage service. It is the only RPC that supports GET because it is literally the method to 'get' resources from IPFS. It doesn't make sense to upload a file via GET. I found it most elegant to just 'convert' the incoming GET request into a POST request and then execute it on the existing API leaving the entire API code untouched. The existing code is very generic making it difficult and ugly to handle the GET inside the 'get_uri' handler (for instance the storage service doesn't even have it's own code but is made up entirely from generic classes/shared code). That's why I handled the GET at the very beginning.